### PR TITLE
fix(cyan-skillfish-governor-smu): use pkgs.formats.toml for settings

### DIFF
--- a/cyan-skillfish-governor-smu/module.nix
+++ b/cyan-skillfish-governor-smu/module.nix
@@ -10,10 +10,11 @@ let
 
   defaultPackage = pkgs.callPackage ./package.nix {};
 
+  tomlFormat = pkgs.formats.toml {};
+
   configFile =
     if cfg.settings != null then
-      pkgs.writeText "cyan-skillfish-governor-smu-config.toml"
-        (lib.generators.toTOML {} cfg.settings)
+      tomlFormat.generate "cyan-skillfish-governor-smu-config.toml" cfg.settings
     else
       cfg.configFile;
 in


### PR DESCRIPTION
`lib.generators.toTOML` does not exist in nixpkgs, so any configuration setting `services.cyan-skillfish-governor-smu.settings` to a non-null value failed to evaluate with "attribute 'toTOML' missing". The option was unusable.