### PR TITLE
feat: add bc250-core-unlock module and package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Simple NixOS module for BC250. Comes with wrapper modules and recommended settin
 - Enable zswap and fastest compression, recommend leaving zram disabled (NixOS default) - [explanation](https://elektricm.github.io/amd-bc250-docs/system/power/?h=zswap#tdp-modification-experimental)
 - ACPI table overrides for CPU idle states and frequency scaling (bc250-acpi-fix) - [docs](https://github.com/e-tho/bc250-acpi-fix)
   - The stock firmware publishes no P-states and a C-state table that never loads
+- CPU core unlocking, 6c/12t to 8c/16t (bc250-core-unlock) - [docs](https://github.com/rw-r-r-0644/bc250-core-unlock)
+  - Make sure to stress test the unlocked cores before relying on them
+  - Triggers a reboot on cold boot to apply the change; warm reboots are unaffected
+  - Append the `bc250.nocoreunlock` kernel parameter at the bootloader to skip the unlock for one boot
 - CU unlocking (bc250-cu-live-manager) - [docs](https://github.com/WinnieLV/bc250-cu-live-manager)
   - Make sure to test the stability of your CU unlock before enabling this
 - CPU overclocking and undervolting (bc250_smu_oc) - [docs](https://github.com/bc250-collective/bc250_smu_oc/)
@@ -47,6 +51,10 @@ Also comes with a wrapper for the AIC8800d80 driver, a chipset used in some WiFi
       # conflicts, check first and either turn those off in the BIOS setup
       # or leave this disabled.
       acpiFix.enable = false;
+
+      # Make sure to stress test the unlocked cores before relying
+      # on them. Triggers a reboot on cold boot to apply the change.
+      coreUnlock.enable = false;
 
       # Null by default. Values are in MB.
       # vramSplit writes UMA_SIZE with bc250memcfg only if CMOS differs.
@@ -111,6 +119,10 @@ Now you can use it in your configuration:
       # conflicts, check first and either turn those off in the BIOS setup
       # or leave this disabled.
       acpiFix.enable = false;
+
+      # Make sure to stress test the unlocked cores before relying
+      # on them. Triggers a reboot on cold boot to apply the change.
+      coreUnlock.enable = false;
       
       # Null by default. Values are in MB.
       # vramSplit writes UMA_SIZE with bc250memcfg only if CMOS differs.

--- a/bc250-core-unlock/module.nix
+++ b/bc250-core-unlock/module.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.bc250-core-unlock;
+in
+{
+  options.services.bc250-core-unlock = {
+    enable = lib.mkEnableOption "BC-250 CPU core unlock during early boot";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      description = "Package providing bc250-core-unlock.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.boot.initrd.systemd.enable;
+        message = ''
+          services.bc250-core-unlock requires boot.initrd.systemd.enable, as the
+          unlock runs as a systemd unit in the initrd.
+        '';
+      }
+    ];
+
+    boot.initrd.systemd.storePaths = [ (lib.getExe cfg.package) ];
+
+    boot.initrd.systemd.services.bc250-core-unlock = {
+      description = "Unlock BC-250 CPU cores";
+      wantedBy = [ "initrd.target" ];
+      before = [ "initrd-root-device.target" ];
+
+      unitConfig = {
+        DefaultDependencies = false;
+        # Escape hatch: append bc250.nocoreunlock at the bootloader to skip.
+        ConditionKernelCommandLine = "!bc250.nocoreunlock";
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        StandardOutput = "journal+console";
+        ExecStart = lib.getExe cfg.package;
+      };
+    };
+  };
+}

--- a/bc250-core-unlock/package.nix
+++ b/bc250-core-unlock/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  writeShellApplication,
+  coreutils,
+  util-linux,
+}:
+
+writeShellApplication {
+  name = "bc250-core-unlock";
+
+  runtimeInputs = [
+    coreutils
+    util-linux
+  ];
+
+  text = ''
+      C=/sys/bus/pci/devices/0000:00:00.0/config
+
+      Q3_CMD='\x20\x0a\xb1\x03'
+      Q3_RSP='\x80\x0a\xb1\x03'
+      Q3_ARG='\x88\x0a\xb1\x03'
+      Q3_ARG_HI='\x8c\x0a\xb1\x03'
+      MASK='\x70\xa8\x05\x00'
+      ZERO='\x00\x00\x00\x00'
+      MSG98='\x98\x00\x00\x00'
+
+      [ -r /proc/cmdline ] || mount -t proc proc /proc 2>/dev/null || true
+
+      if ! cmdline=$(cat /proc/cmdline 2>/dev/null); then
+        echo "bc250-core-unlock: cannot read kernel command line, refusing"
+        exit 0
+      fi
+
+      case "$cmdline" in
+        *bc250.nocoreunlock*)
+          echo "bc250-core-unlock: disabled via kernel command line"
+          exit 0
+          ;;
+      esac
+
+      if [ ! -e "$C" ]; then
+        echo "bc250-core-unlock: no PCI config space at $C"
+        exit 0
+      fi
+
+      smn_addr() { printf "%b" "$1" | dd of="$C" bs=1 seek=184 conv=notrunc status=none; }
+
+      smn_rd() {
+        smn_addr "$1"
+        dd if="$C" bs=1 skip=188 count=4 status=none | od -An -tx1 | tr -d ' '
+      }
+
+      smn_wr() {
+        smn_addr "$1"
+        printf "%b" "$2" | dd of="$C" bs=1 seek=188 conv=notrunc status=none
+      }
+
+      mailbox_wait() {
+        i=0
+        while [ "$i" -lt 250 ]; do
+          case "$(smn_rd "$Q3_RSP")" in
+            01000000|ff000000|fe000000|fd000000|fc000000) return 0 ;;
+          esac
+          sleep 0.02
+          i=$((i + 1))
+        done
+        return 1
+      }
+
+      before=$(smn_rd "$MASK")
+    echo "bc250-core-unlock: core presence mask is $before"
+
+    case "$before" in
+      ff000000)
+        echo "bc250-core-unlock: already unlocked, continuing boot"
+        exit 0
+        ;;
+      77000000) ;;
+      *)
+        echo "bc250-core-unlock: unexpected mask, refusing"
+        echo "bc250-core-unlock: a mask other than 0x77 suggests a harvest that skipped defective cores"
+        exit 0
+        ;;
+    esac
+
+    if ! mailbox_wait; then
+      echo "bc250-core-unlock: SMU mailbox busy, not writing"
+      exit 0
+    fi
+
+    smn_wr "$Q3_RSP" "$ZERO"
+    smn_wr "$Q3_ARG" "$MASK"
+    smn_wr "$Q3_ARG_HI" "$ZERO"
+    smn_wr "$Q3_CMD" "$MSG98"
+
+    if ! mailbox_wait; then
+      echo "bc250-core-unlock: SMU mailbox timeout, not resetting"
+      exit 0
+    fi
+
+    status=$(smn_rd "$Q3_RSP")
+    if [ "$status" != "01000000" ]; then
+      echo "bc250-core-unlock: SMU returned $status, not resetting"
+      exit 0
+    fi
+
+    sleep 0.2
+    after=$(smn_rd "$MASK")
+    if [ "$after" != "ff000000" ]; then
+      echo "bc250-core-unlock: mask did not take ($after), not resetting"
+      exit 0
+    fi
+
+    echo "bc250-core-unlock: mask written, resetting"
+    sleep 1
+    echo b > /proc/sysrq-trigger
+  '';
+
+  meta = {
+    description = "Enable the two disabled CPU cores on the AMD BC-250 during early boot";
+    longDescription = ''
+      Shell reimplementation of bc250-core-unlock, adapted to run as a systemd
+      unit in the initrd. Triggers a reboot on cold boot to apply the unlock.
+      See the original script and documentation at
+      https://github.com/rw-r-r-0644/bc250-core-unlock.
+    '';
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "bc250-core-unlock";
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ in
   imports = [
     ./aic8800d80/module.nix
     ./bc250-acpi-fix/module.nix
+    ./bc250-core-unlock/module.nix
     ./bc250-cu-live-manager/module.nix
     ./bc250-memcfg/module.nix
     ./cyan-skillfish-governor-smu/module.nix
@@ -21,6 +22,7 @@ in
       sensors.enable = lib.mkEnableOption "nct6687 sensor support" // { default = true; };
       cuLiveManager.enable = lib.mkEnableOption "BC-250 CU live manager";
       acpiFix.enable = lib.mkEnableOption "ACPI table overrides for CPU idle states and frequency scaling";
+      coreUnlock.enable = lib.mkEnableOption "BC-250 CPU core unlock (6c/12t to 8c/16t)";
       vramSplit = lib.mkOption {
         type = lib.types.nullOr lib.types.int;
         default = null;
@@ -78,6 +80,10 @@ in
 
     (lib.mkIf cfg.features.acpiFix.enable {
       services.bc250-acpi-fix.enable = lib.mkDefault true;
+    })
+
+    (lib.mkIf cfg.features.coreUnlock.enable {
+      services.bc250-core-unlock.enable = lib.mkDefault true;
     })
 
     (lib.mkIf (cfg.features.vramSplit != null) {


### PR DESCRIPTION
The BC-250's CPU has 2 of its 8 cores disabled. They can be enabled at runtime, but a power cycle reverts them, so the unlock has to be reapplied on every cold boot.

Add a shell reimplementation of bc250-core-unlock, running as a systemd unit in the initrd, which enables the cores and reboots to apply the change. Appending the bc250.nocoreunlock kernel parameter at the bootloader skips it.

Disabled by default: the unlocked cores may be defective and should be stress tested first.

Original script and documentation:
https://github.com/rw-r-r-0644/bc250-core-unlock